### PR TITLE
Pitch diameter Sketch

### DIFF
--- a/Fission/fission.py
+++ b/Fission/fission.py
@@ -505,7 +505,7 @@ class InputFactory(FusionEventHandler):
             except RuntimeError as e:
                 # This prevents an exception from being thrown when opening the window if the helix angle is 0
                 # TODO: this works but is this the right way?
-                return um.evaluateExpression(str(input.value), units)
+                return input.value
 
         input.eval = lambda: evalInput()
 

--- a/Fission/fission.py
+++ b/Fission/fission.py
@@ -498,7 +498,17 @@ class InputFactory(FusionEventHandler):
         self._set_tips(input, name, tooltip, description, help_image)
         um = self._unitsMgr
         du = self._design_utils
-        input.eval = lambda: um.evaluateExpression(input.expression, units)
+
+        def evalInput():
+            try:
+                return um.evaluateExpression(input.expression, units)
+            except RuntimeError as e:
+                # This prevents an exception from being thrown when opening the window if the helix angle is 0
+                # TODO: this works but is this the right way?
+                return um.evaluateExpression(str(input.value), units)
+
+        input.eval = lambda: evalInput()
+
         self.handle_change(input, on_change)
         self.handle_validate(input, on_validate)
         if persist:

--- a/HelicalGear.py
+++ b/HelicalGear.py
@@ -666,7 +666,8 @@ class HelicalGearAddin(fission.CommandBase):
             'herringbone': False,
             'inner_gear': False,
             'inner_gear_clearance': 0.25,
-            'inner_gear_outer_diameter': 0}
+            'inner_gear_outer_diameter': 0,
+            'pitch_diameter_sketch': True}
 
     @property
     def is_repeatable(self):
@@ -789,6 +790,12 @@ Sunderland: The Sunderland machine is commonly used to make a double helical gea
             'Base Feature',
             self.pers['base_feature'],
             tooltip='Generates as a base feature when checked. Slightly better performance when recomputing.',
+            persist=False)
+        self.pitch_diameter_sketch = factory.create_checkbox(
+            'pitch_diameter_sketch',
+            'Pitch Diameter Sketch',
+            self.pers['pitch_diameter_sketch'],
+            tooltip='Adds a Sketch that contains the pitch diameter.',
             persist=False)
         self.full_preview = factory.create_checkbox(
             'full_preview',
@@ -950,7 +957,8 @@ Sunderland: The Sunderland machine is commonly used to make a double helical gea
                   self.herringbone,
                   self.inner_gear,
                   self.inner_gear_clearance,
-                  self.inner_gear_outer_diameter]:
+                  self.inner_gear_outer_diameter,
+                  self.pitch_diameter_sketch]:
             self.pers[i.id] = i.value
 
     def on_preview(self, args) -> 'preview':
@@ -1098,6 +1106,7 @@ Sunderland: The Sunderland machine is commonly used to make a double helical gea
                                                                   adsk.fusion.FeatureOperations.NewBodyFeatureOperation)
         sweepInput.twistAngle = adsk.core.ValueInput.createByString(str(pitch_helix.t_for(thickness)) + " rad")
         sweepFeature = component.features.sweepFeatures.add(sweepInput)
+        last_timeline_object = sweepFeature.timelineObject
 
         if (self.herringbone.value):
             sweepInput2 = component.features.sweepFeatures.createInput(profs, path2,
@@ -1106,23 +1115,30 @@ Sunderland: The Sunderland machine is commonly used to make a double helical gea
                                                                        adsk.fusion.FeatureOperations.JoinFeatureOperation)
             sweepInput2.twistAngle = adsk.core.ValueInput.createByString(str(-pitch_helix.t_for(thickness)) + " rad")
             sweepFeature2 = component.features.sweepFeatures.add(sweepInput2)
+            last_timeline_object = sweepFeature2.timelineObject
 
         print(self.base_feature.value)
         print(self.design.design.designType)
 
         if self.base_feature.value:
             self.basefeat.finishEdit()
-            timelineGroups = self.design.design.timeline.timelineGroups
-            endIndex = self.basefeat.timelineObject.index
-            timelineGroup = timelineGroups.add(endIndex - 1, endIndex)
-            timelineGroup.name = component.name
-        else:
-            if self.design.design.designType:
-                timelineGroups = self.design.design.timeline.timelineGroups
-                startIndex = component.features[0].timelineObject.index - 2  # <--   Not good code but works
-                endIndex = sweepFeature.timelineObject.index + (1 if self.herringbone.value else 0)
-                timelineGroup = timelineGroups.add(startIndex, endIndex)
-                timelineGroup.name = component.name
+            last_timeline_object = self.basefeat.timelineObject
+
+        # Add pitch diameter sketch
+        if self.pitch_diameter_sketch.value:
+            pitch_diameter_sketch = component.sketches.add(component.xYConstructionPlane)
+            pitch_diameter_sketch.name = 'Pitch Diameter'
+            pitch_diameter_circle = pitch_diameter_sketch.sketchCurves.sketchCircles.addByCenterRadius(
+                fission.Point3D(0, 0),
+                gear.pitch_diameter / 2)
+            pitch_diameter_circle.isConstruction = True
+            last_timeline_object = pitch_diameter_sketch.timelineObject
+
+        if self.design.design.designType:
+            timeline_groups = self.design.design.timeline.timelineGroups
+            timeline_group = timeline_groups.add(component.occurrence.timelineObject.index,
+                                                 last_timeline_object.index)
+            timeline_group.name = component.name
 
         sketch.isVisible = False
 

--- a/HelicalGear.py
+++ b/HelicalGear.py
@@ -1132,6 +1132,7 @@ Sunderland: The Sunderland machine is commonly used to make a double helical gea
                 fission.Point3D(0, 0),
                 gear.pitch_diameter / 2)
             pitch_diameter_circle.isConstruction = True
+            pitch_diameter_circle.isFixed = True
             last_timeline_object = pitch_diameter_sketch.timelineObject
 
         if self.design.design.designType:

--- a/HelicalGear.py
+++ b/HelicalGear.py
@@ -751,7 +751,7 @@ Sunderland: The Sunderland machine is commonly used to make a double helical gea
         self.backlash = factory.addValueInput(
             'backlash',
             'Backlash',
-            str(self.pers['backlash']), 'mm', persist=False,
+            self.pers['backlash'], 'mm', persist=False,
             description='[experimental] a positive value here causes each tooth to be slightly narrower than the ideal tooth. In the real world having a perfect tooth is not often desired, it is better to build in a little backlash to reduce friction, allow room for lubricant between teeth, and to prevent jamming.\n\nBacklash is allowed to also be negative which has no real world application I\'m aware of but may be useful for compensating for undersized teeth which were 3D printed, etc.\n\nThe backlash value is split between this gear and its theoretical mate.')
         self.gear_thickness = factory.addValueInput(
             'gear_thickness',


### PR DESCRIPTION
Adds another checkbox which causes the script to add a sketch containing the pitch diameter.
This functionality is also supported by the fusion 360 built-in spur gear script.